### PR TITLE
refactor: replace @slf4j with runContext.logger()

### DIFF
--- a/src/test/java/io/kestra/plugin/datagen/services/DataEmitterTest.java
+++ b/src/test/java/io/kestra/plugin/datagen/services/DataEmitterTest.java
@@ -2,13 +2,14 @@ package io.kestra.plugin.datagen.services;
 
 import io.kestra.core.exceptions.IllegalVariableEvaluationException;
 import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.runners.RunContext;
 import io.kestra.core.runners.RunContextFactory;
 import io.kestra.plugin.datagen.Data;
 import io.kestra.plugin.datagen.generators.StringValueGenerator;
 import io.kestra.plugin.datagen.model.Producer;
 import jakarta.inject.Inject;
-import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
 
 import java.time.Duration;
 import java.util.ArrayList;
@@ -17,7 +18,6 @@ import java.util.function.Consumer;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
-@Slf4j
 @KestraTest
 class DataEmitterTest {
 
@@ -28,11 +28,13 @@ class DataEmitterTest {
     void shouldGenerateData() throws IllegalVariableEvaluationException {
         // Given
         List<Data> generated = new ArrayList<>(10);
+        RunContext runContext = runContextFactory.of();
         StringValueGenerator generator = StringValueGenerator
             .builder()
             .value("value")
             .build();
-        generator.init(runContextFactory.of());
+        generator.init(runContext);
+        Logger logger = runContext.logger();
 
         Consumer<Data> consumer = generated::add;
         Producer<Data> producer = () -> {
@@ -45,7 +47,7 @@ class DataEmitterTest {
         };
 
         DataEmitterOptions options = new DataEmitterOptions(10L, DataEmitterOptions.NO_THROUGHPUT, Duration.ZERO);
-        DataEmitter task = new DataEmitter(producer, consumer, options, log);
+        DataEmitter task = new DataEmitter(producer, consumer, options, logger);
 
         // When
         task.run();


### PR DESCRIPTION
This PR removes `@Slf4j` from `DataEmitterTest` and replaces it with execution-specific `runContext.logger()` to align with project-wide logging conventions.

### What changes are being made and why?

- Removed `@Slf4j` annotation from test class
- Extracted `RunContext` to a local variable for reuse
- Use `runContext.logger()` instead of static logger for execution-aware logging

Related to kestra-io/kestra#12770

---

### How the changes have been QAed?

✅ All existing unit tests pass successfully
✅ Code compiles with no errors or warnings
✅ No functional changes - refactoring only