### PR TITLE
fix realtime trigger

### DIFF
--- a/src/main/java/io/kestra/plugin/datagen/core/RealtimeTrigger.java
+++ b/src/main/java/io/kestra/plugin/datagen/core/RealtimeTrigger.java
@@ -194,11 +194,13 @@ public class RealtimeTrigger extends AbstractTrigger implements RealtimeTriggerI
             return;
         }
 
+        // Always halt the emitter; wait only when killing (blocking).
+        if (dataEmitter != null) {
+            dataEmitter.stop();
+        }
+
         if (wait) {
             try {
-                if (dataEmitter != null) {
-                    dataEmitter.stop();
-                }
                 waitForTermination.await();
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();

--- a/src/main/java/io/kestra/plugin/datagen/services/DataEmitter.java
+++ b/src/main/java/io/kestra/plugin/datagen/services/DataEmitter.java
@@ -64,11 +64,12 @@ public class DataEmitter implements Runnable {
                 Data data = producer.produce();
                 Callback cb = stats.nextCompletion(sendStartMs, data.getSize(), stats);
                 doSendData(data, cb);
-                if (throttler.shouldThrottle(options.numExecutions(), sendStartMs)) {
-                    throttler.throttle();
-                }
 
                 i++;
+
+                if (throttler.shouldThrottle(i, sendStartMs)) {
+                    throttler.throttle();
+                }
 
                 if (i >= options.numExecutions()) {
                     logger.info("Reach maximum number of data generation {}", options.numExecutions());

--- a/src/test/java/io/kestra/plugin/datagen/core/RealtimeTriggerTest.java
+++ b/src/test/java/io/kestra/plugin/datagen/core/RealtimeTriggerTest.java
@@ -1,0 +1,65 @@
+package io.kestra.plugin.datagen.core;
+
+import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.plugin.datagen.Data;
+import io.kestra.plugin.datagen.services.DataEmitter;
+import io.kestra.plugin.datagen.services.DataEmitterOptions;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+
+import java.lang.reflect.Field;
+import java.time.Duration;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@KestraTest
+class RealtimeTriggerTest {
+
+    /**
+     * A {@link DataEmitter} test double that records whether {@link #stop()} was invoked,
+     * without blocking on termination.
+     */
+    static class RecordingDataEmitter extends DataEmitter {
+        final AtomicBoolean stopped = new AtomicBoolean(false);
+
+        RecordingDataEmitter() {
+            super(
+                () -> Data.builder().value("v").size(1L).build(),
+                data -> {},
+                new DataEmitterOptions(Long.MAX_VALUE, DataEmitterOptions.NO_THROUGHPUT, Duration.ofSeconds(15)),
+                LoggerFactory.getLogger(RealtimeTriggerTest.class)
+            );
+        }
+
+        @Override
+        public void stop() {
+            stopped.set(true);
+        }
+    }
+
+    @Test
+    void shouldStopEmitterOnNonBlockingStop() throws Exception {
+        // Given a trigger with a running emitter.
+        RealtimeTrigger trigger = RealtimeTrigger.builder()
+            .id(UUID.randomUUID().toString())
+            .type(RealtimeTrigger.class.getName())
+            .build();
+
+        RecordingDataEmitter emitter = new RecordingDataEmitter();
+        injectEmitter(trigger, emitter);
+
+        // When the (non-blocking) stop() is called.
+        trigger.stop();
+
+        // Then the emitter must be halted, even though stop() does not wait for termination.
+        assertThat(emitter.stopped.get()).isTrue();
+    }
+
+    private static void injectEmitter(RealtimeTrigger trigger, DataEmitter emitter) throws Exception {
+        Field field = RealtimeTrigger.class.getDeclaredField("dataEmitter");
+        field.setAccessible(true);
+        field.set(trigger, emitter);
+    }
+}

--- a/src/test/java/io/kestra/plugin/datagen/services/DataEmitterTest.java
+++ b/src/test/java/io/kestra/plugin/datagen/services/DataEmitterTest.java
@@ -55,4 +55,48 @@ class DataEmitterTest {
         // Then
         assertThat(generated.size()).isEqualTo(10);
     }
+
+    @Test
+    void shouldEnforceMaxThroughput() throws IllegalVariableEvaluationException {
+        // Given a finite run with a bounded throughput.
+        // The throttler is fed the running sent count, so it actually limits the rate:
+        // emitting N records at T/s must take at least ~ (N - 1) / T seconds.
+        final long throughput = 20L;
+        final long numExecutions = 20L;
+
+        List<Data> generated = new ArrayList<>((int) numExecutions);
+        RunContext runContext = runContextFactory.of();
+        StringValueGenerator generator = StringValueGenerator
+            .builder()
+            .value("value")
+            .build();
+        generator.init(runContext);
+        Logger logger = runContext.logger();
+
+        Consumer<Data> consumer = generated::add;
+        Producer<Data> producer = () -> {
+            String val = generator.produce();
+            return Data
+                .builder()
+                .value(val)
+                .size((long) val.length())
+                .build();
+        };
+
+        DataEmitterOptions options = new DataEmitterOptions(numExecutions, throughput, Duration.ZERO);
+        DataEmitter task = new DataEmitter(producer, consumer, options, logger);
+
+        // When
+        long startMs = System.currentTimeMillis();
+        task.run();
+        long elapsedMs = System.currentTimeMillis() - startMs;
+
+        // Then
+        // All records are emitted...
+        assertThat(generated.size()).isEqualTo((int) numExecutions);
+        // ...and throttling kept the effective rate at or below the configured throughput.
+        // Without enforcement the run would complete almost instantly; here it must be throttled.
+        long minExpectedMs = (numExecutions - 1) * 1000L / throughput;
+        assertThat(elapsedMs).isGreaterThanOrEqualTo((long) (minExpectedMs * 0.7));
+    }
 }


### PR DESCRIPTION
Two fixes:

**fix(core): throttle on actual sent count, not target count**
    
shouldThrottle() was passed options.numExecutions() (the fixed target)
instead of the running sent count, so the rate limiter never tracked
real throughput: it over-throttled at start then disabled itself,
leaving maxThroughput effectively unenforced. Pass the running counter.

**fix(core): always stop emitter on RealtimeTrigger stop**

Move dataEmitter.stop() out of the wait-only branch so the emitter is
always halted; only block on termination when wait is true.
